### PR TITLE
- fix ResultSurrogateConverter<TValue> value types

### DIFF
--- a/src/Orleans.Serialization.FluentResults/[Results]/ResultSurrogateConverter.cs
+++ b/src/Orleans.Serialization.FluentResults/[Results]/ResultSurrogateConverter.cs
@@ -26,7 +26,7 @@ public sealed class ResultSurrogateConverter<TValue> :
   {
 
     var result = new Result<TValue>().WithReasons(surrogate.Reasons);
-    if (surrogate.Value is not null)
+    if (surrogate.Reasons.Count == 0 && surrogate.Value is not null)
     {
       result.WithValue(surrogate.Value);
     }


### PR DESCRIPTION
This Fix fixes issue with converting Result<T> where T is stuct. 
`surrogate.Value is not null` will be always true to value types or stucts. For example: `Result<bool>` in Failed state will crash in `ResultSurrogateConverter.cs`

```
System.InvalidOperationException
Result is in status failed. Value is not set. Having: Error with Message='$', Reasons='Error with Message='ERROR''
   at FluentResults.Result`1.ThrowIfFailed()
   at FluentResults.Result`1.set_Value(TValue value)
   at FluentResults.Result`1.WithValue(TValue value)
   at Orleans.Serialization.FluentResults.ResultSurrogateConverter`1.ConvertFromSurrogate(ResultSurrogate`1& surrogate)
   at Orleans.Serialization.FluentResults.ResultSurrogateConverter`1.Orleans.IConverter<FluentResults.Result<TValue>,Orleans.Serialization.FluentResults.ResultSurrogate<TValue>>.ConvertFromSurrogate(ResultSurrogate`1& surrogate)
```